### PR TITLE
commented out warnings in submit_image_graph.sh

### DIFF
--- a/summit_demo/integrate/submit_image_graph.sh
+++ b/summit_demo/integrate/submit_image_graph.sh
@@ -114,8 +114,8 @@ function get_measurement_sets {
 			files+=("$file")
 		elif [ -d "$file" ]; then
 			get_measurement_sets "$file/*"
-		else
-			warning "Ignoring $file, not a measurement set"
+#		else
+#			warning "Ignoring $file, not a measurement set"
 		fi
 	done
 }


### PR DESCRIPTION
This warning prints too much information for large-scale simulations, which slows down the job submission process.