### PR TITLE
modified image pipeline job submission script so that it can run an arbitrary number of processes per node

### DIFF
--- a/summit_demo/integrate/run_image_graph_nodlg.sh
+++ b/summit_demo/integrate/run_image_graph_nodlg.sh
@@ -2,6 +2,8 @@
 
 venv="$1"
 outdir="$2"
+processes_per_node="$3"
+total_processes="$4"
 
 . common.sh
 
@@ -11,13 +13,20 @@ echo "outdir = $outdir"
 echo "**************************************"
 
 load_modules
-runner="`get_runner mpi 1`"
-echo "Using $runner to start cimager"
 
 env > $outdir/env.txt
 git rev-parse HEAD > $outdir/commit.txt
-rank=${SLURM_ARRAY_TASK_ID:-$LSB_JOBINDEX}
+subjob_id=${SLURM_ARRAY_TASK_ID:-$LSB_JOBINDEX}
+starting_process_id=$(( ($subjob_id - 1) * ($processes_per_node) + 1 ))
+ending_process_id=$(( $subjob_id * $processes_per_node ))
+total_processes=$(( $total_processes + 1 ))
 
-cd "$outdir/$rank"
-
-$runner cimager -c imager.ini
+for r in `seq $starting_process_id $ending_process_id`
+do
+    if [ $total_processes -gt $r ]; then
+        cd "$outdir/$r"
+        pwd
+        jsrun -n1 -a1 -c1 cimager -c imager.ini > cimager.log &
+        cd "../.."
+    fi
+done

--- a/summit_demo/integrate/run_image_graph_nodlg.sh
+++ b/summit_demo/integrate/run_image_graph_nodlg.sh
@@ -10,9 +10,11 @@ total_processes="$4"
 banner "Arguments passed from job script"
 echo "venv = $venv"
 echo "outdir = $outdir"
+echo "processes_per_node = $processes_per_node"
+echo "total_processes = $total_processes"
 echo "**************************************"
-
 load_modules
+echo "**************************************"
 
 env > $outdir/env.txt
 git rev-parse HEAD > $outdir/commit.txt
@@ -21,6 +23,7 @@ starting_process_id=$(( ($subjob_id - 1) * ($processes_per_node) + 1 ))
 ending_process_id=$(( $subjob_id * $processes_per_node ))
 total_processes=$(( $total_processes + 1 ))
 
+banner "Processing visibility data"
 for r in `seq $starting_process_id $ending_process_id`
 do
     if [ $total_processes -gt $r ]; then
@@ -30,3 +33,4 @@ do
         cd "../.."
     fi
 done
+echo "**************************************"


### PR DESCRIPTION
The original script only runs one process per node for imaging, while the other 41 CPU cores are idle. This should fix it so that it can use all CPU core of a Summit node.