### PR TITLE
Add Eagle Component Descriptions

### DIFF
--- a/apps/askap/factory/CalcNE.h
+++ b/apps/askap/factory/CalcNE.h
@@ -35,9 +35,15 @@ namespace askap {
     * \param gitrepo $(GIT_REPO)
     * \param version $(PROJECT_VERSION)
     * \param category DynlibApp
-    * \param[in] param/Config
-    * \param[in] param/Model
-    * \param[out] param/Normal
+    * \param[in] port/Config/LOFAR::ParameterSet
+    *     /~English ParameterSet descriptor for the image solver
+    *     /~Chinese
+    * \param[in] port/Model/scimath::Params
+    *     /~English Params of solved normal equations
+    *     /~Chinese
+    * \param[out] port/Normal/scimath::ImagingNormalEquations
+    *     /~English ImagingNormalEquations to solve
+    *     /~Chinese
     * \par EAGLE_END
     */
     class CalcNE : public DaliugeApplication
@@ -61,10 +67,6 @@ namespace askap {
         virtual void data_written(const char *uid, const char *data, size_t n);
 
         virtual void drop_completed(const char *uid, drop_status status);
-
-
-
-
 
         private:
 

--- a/apps/askap/factory/CalcNE.h
+++ b/apps/askap/factory/CalcNE.h
@@ -27,14 +27,21 @@
 
 namespace askap {
 
-    /// @brief Calculates the Normal Equations
-    /// @details This class encorporates all the tasks to read from a measurement set;
-    /// subtract a model; grid residual visibilities and FFT the grid
-
+    /*!
+    * \brief Calculates the Normal Equations
+    * \details This class encorporates all the tasks to read from a measurement set;
+    *  subtract a model; grid residual visibilities and FFT the grid
+    * \par EAGLE_START
+    * \param gitrepo $(GIT_REPO)
+    * \param version $(PROJECT_VERSION)
+    * \param category DynlibApp
+    * \param[in] param/Config
+    * \param[in] param/Model
+    * \param[out] param/Normal
+    * \par EAGLE_END
+    */
     class CalcNE : public DaliugeApplication
-
     {
-
     public:
 
         typedef boost::shared_ptr<CalcNE> ShPtr;

--- a/apps/askap/factory/DaliugeApplicationFactory.h
+++ b/apps/askap/factory/DaliugeApplicationFactory.h
@@ -50,7 +50,7 @@ namespace askap
       /// (in lowercase) is loaded and it executes its register<name>
       /// function which must register its creator function in the registry
       /// using function registerDaliugeApplication.
-      /// @param name The name function
+      /// @param dlg_app The name function
       ///
 
       static DaliugeApplication::ShPtr createDaliugeApplication (dlg_app_info *dlg_app);

--- a/apps/askap/factory/InitSpectralCube.cc
+++ b/apps/askap/factory/InitSpectralCube.cc
@@ -182,7 +182,7 @@ namespace askap {
 
 
         casacore::Quantity f0(baseFrequency,"Hz");
-    /// The width of a channel. THis does <NOT> take account of the variable width
+    /// The width of a channel. THis does NOT take account of the variable width
     /// of Barycentric channels
         casacore::Quantity freqinc(chanWidth,"Hz");
 

--- a/apps/askap/factory/InitSpectralCube.h
+++ b/apps/askap/factory/InitSpectralCube.h
@@ -39,7 +39,12 @@ namespace askap {
     * \param gitrepo $(GIT_REPO)
     * \param version $(PROJECT_VERSION)
     * \param category DynlibApp
-    * \param[in] param/Config
+    * \param[in] port/Config/LOFAR::ParameterSet
+    *     /~English ParameterSet descriptor for the image solver
+    *     /~Chinese
+    * \param[out] port/Cube/undefined
+    *     /~English
+    *     /~Chinese
     * \par EAGLE_END
     */
     class InitSpectralCube : public DaliugeApplication

--- a/apps/askap/factory/InitSpectralCube.h
+++ b/apps/askap/factory/InitSpectralCube.h
@@ -31,16 +31,19 @@
 
 
 namespace askap {
-
-    /// @brief Build the output image cube
-    /// @details This class builds the output cube is whatever format specified
-    /// by the parset.
-    ///
-
+    /*!
+    * \brief Build the output image cube
+    * \details This class builds the output cube is whatever format specified
+    * by the parset.
+    * \par EAGLE_START
+    * \param gitrepo $(GIT_REPO)
+    * \param version $(PROJECT_VERSION)
+    * \param category DynlibApp
+    * \param[in] param/Config
+    * \par EAGLE_END
+    */
     class InitSpectralCube : public DaliugeApplication
-
     {
-
     public:
 
         typedef boost::shared_ptr<InitSpectralCube> ShPtr;

--- a/apps/askap/factory/JacalBPCalibrator.h
+++ b/apps/askap/factory/JacalBPCalibrator.h
@@ -50,10 +50,15 @@ namespace askap
     * \param gitrepo $(GIT_REPO)
     * \param version $(PROJECT_VERSION)
     * \param category DynlibApp
-    * \param[in] param/Config
-    * \param[in] param/Model
-    * \param[in] param/theInput TODO
-    * \param[out] param/Model
+    * \param[in] port/Config/LOFAR::ParameterSet
+    *     /~English ParameterSet descriptor for the image solver
+    *     /~Chinese
+    * \param[in] port/Model/scimath::Params
+    *     /~English Params of solved normal equations
+    *     /~Chinese
+    * \param[out] port/Model/scimath::Params
+    *     /~English
+    *     /~Chinese
     * \par EAGLE_END
     */
     class JacalBPCalibrator : public DaliugeApplication

--- a/apps/askap/factory/JacalBPCalibrator.h
+++ b/apps/askap/factory/JacalBPCalibrator.h
@@ -43,8 +43,19 @@
 
 namespace askap
 {
-
-
+    /*!
+    * \brief
+    * \details
+    * \par EAGLE_START
+    * \param gitrepo $(GIT_REPO)
+    * \param version $(PROJECT_VERSION)
+    * \param category DynlibApp
+    * \param[in] param/Config
+    * \param[in] param/Model
+    * \param[in] param/theInput TODO
+    * \param[out] param/Model
+    * \par EAGLE_END
+    */
     class JacalBPCalibrator : public DaliugeApplication
     {
       public:

--- a/apps/askap/factory/LoadNE.h
+++ b/apps/askap/factory/LoadNE.h
@@ -32,7 +32,9 @@ namespace askap {
     * \param gitrepo $(GIT_REPO)
     * \param version $(PROJECT_VERSION)
     * \param category DynlibApp
-    * \param[in] param/0
+    * \param[in] port/Normal/scimath::ImagingNormalEquations
+    *     /~English ImagingNormalEquations to solve
+    *     /~Chinese
     * \par EAGLE_END
     */
     class LoadNE : public DaliugeApplication

--- a/apps/askap/factory/LoadNE.h
+++ b/apps/askap/factory/LoadNE.h
@@ -25,12 +25,18 @@
 
 
 namespace askap {
-    /// @brief Example calss that simply loads Normal Equations from a drop
-    /// @details Just accepts the drop
+    /*!
+    * \brief Example class that simply loads Normal Equations from a drop
+    * \details Just accepts the drop
+    * \par EAGLE_START
+    * \param gitrepo $(GIT_REPO)
+    * \param version $(PROJECT_VERSION)
+    * \param category DynlibApp
+    * \param[in] param/0
+    * \par EAGLE_END
+    */
     class LoadNE : public DaliugeApplication
-
     {
-
     public:
 
         typedef boost::shared_ptr<LoadNE> ShPtr;

--- a/apps/askap/factory/LoadParset.h
+++ b/apps/askap/factory/LoadParset.h
@@ -17,12 +17,19 @@
 
 
 namespace askap {
-    /// @brief Loads a configuration
-    /// @details Loads a configuration from a file drop and generates a LOFAR::ParameterSet
+    /*!
+    * \brief Loads a configuration
+    * \details Loads a configuration from a file drop and generates a LOFAR::ParameterSet
+    * \par EAGLE_START
+    * \param gitrepo $(GIT_REPO)
+    * \param version $(PROJECT_VERSION)
+    * \param category DynlibApp
+    * \param[in] param/0
+    * \param[out] param/TODO
+    * \par EAGLE_END
+    */
     class LoadParset : public DaliugeApplication
-
     {
-
     public:
 
         typedef boost::shared_ptr<LoadParset> ShPtr;

--- a/apps/askap/factory/LoadParset.h
+++ b/apps/askap/factory/LoadParset.h
@@ -24,8 +24,11 @@ namespace askap {
     * \param gitrepo $(GIT_REPO)
     * \param version $(PROJECT_VERSION)
     * \param category DynlibApp
-    * \param[in] param/0
-    * \param[out] param/TODO
+    * \param[in] port/Config/LOFAR::ParameterSet
+    *     /~English ParameterSet descriptor for the image solver
+    *     /~Chinese
+    * \param[out] port/Config/LOFAR::ParameterSet
+    * \param[out] port/Config/LOFAR::ParameterSet
     * \par EAGLE_END
     */
     class LoadParset : public DaliugeApplication

--- a/apps/askap/factory/LoadVis.cc
+++ b/apps/askap/factory/LoadVis.cc
@@ -182,7 +182,7 @@ namespace askap {
               NEUtils::receiveParams(itsModel, input("Model"));
             }
             catch (std::runtime_error) {
-              ASKAPLOG_INFO_STR(logger, "Failed to receive model setting up empty one");
+              ASKAPLOG_INFO_STR(logger, "Failed to receive model, setting up empty one");
               askap::synthesis::SynthesisParamsHelper::setUpImages(itsModel,
                                         this->itsParset.makeSubset("Images."));
             }

--- a/apps/askap/factory/LoadVis.h
+++ b/apps/askap/factory/LoadVis.h
@@ -27,12 +27,20 @@
 
 
 namespace askap {
-  /// @brief Loads visibility set
-  /// @details Loads a configuration from a file drop and a visibility set from a casacore::Measurement Set
+    /*!
+    * \brief Loads visibility set
+    * \details Loads a configuration from a file drop and a visibility set from a casacore::Measurement Set
+    * \par EAGLE_START
+    * \param gitrepo $(GIT_REPO)
+    * \param version $(PROJECT_VERSION)
+    * \param category DynlibApp
+    * \param[in] param/Config
+    * \param[in] param/Model
+    * \param[out] param/Normal
+    * \par EAGLE_END
+    */
     class LoadVis : public DaliugeApplication
-
     {
-
     public:
 
         typedef boost::shared_ptr<LoadVis> ShPtr;

--- a/apps/askap/factory/LoadVis.h
+++ b/apps/askap/factory/LoadVis.h
@@ -34,9 +34,15 @@ namespace askap {
     * \param gitrepo $(GIT_REPO)
     * \param version $(PROJECT_VERSION)
     * \param category DynlibApp
-    * \param[in] param/Config
-    * \param[in] param/Model
-    * \param[out] param/Normal
+    * \param[in] port/Config/LOFAR::ParameterSet
+    *     /~English ParameterSet descriptor for the image solver
+    *     /~Chinese
+    * \param[in] port/Model/scimath::Params
+    *     /~English Params of solved normal equations
+    *     /~Chinese
+    * \param[out] port/Normal/scimath::ImagingNormalEquations
+    *     /~English ImagingNormalEquations to solve
+    *     /~Chinese
     * \par EAGLE_END
     */
     class LoadVis : public DaliugeApplication

--- a/apps/askap/factory/MajorCycle.h
+++ b/apps/askap/factory/MajorCycle.h
@@ -33,9 +33,15 @@ namespace askap {
     * \param gitrepo $(GIT_REPO)
     * \param version $(PROJECT_VERSION)
     * \param category DynlibApp
-    * \param[in] param/Config
-    * \param[in] param/Solved Model
-    * \param[out] param/Normal
+    * \param[in] port/Config/LOFAR::ParameterSet
+    *     /~English ParameterSet descriptor for the image solver
+    *     /~Chinese
+    * \param[in] port/Solved Model/scimath::Params
+    *     /~English
+    *     /~Chinese
+    * \param[out] port/Normal/scimath::ImagingNormalEquations
+    *     /~English ImagingNormalEquations to solve
+    *     /~Chinese
     * \par EAGLE_END
     */
     class MajorCycle : public DaliugeApplication

--- a/apps/askap/factory/MajorCycle.h
+++ b/apps/askap/factory/MajorCycle.h
@@ -26,12 +26,20 @@
 
 
 namespace askap {
-  /// @brief Loads visibility set
-  /// @details Loads a configuration from a file drop and a visibility set from a casacore::Measurement Set
+    /*!
+    * \brief Loads visibility set
+    * \details Loads a configuration from a file drop and a visibility set from a casacore::Measurement Set
+    * \par EAGLE_START
+    * \param gitrepo $(GIT_REPO)
+    * \param version $(PROJECT_VERSION)
+    * \param category DynlibApp
+    * \param[in] param/Config
+    * \param[in] param/Solved Model
+    * \param[out] param/Normal
+    * \par EAGLE_END
+    */
     class MajorCycle : public DaliugeApplication
-
     {
-
     public:
 
         typedef boost::shared_ptr<MajorCycle> ShPtr;

--- a/apps/askap/factory/NESpectralCube.cc
+++ b/apps/askap/factory/NESpectralCube.cc
@@ -197,7 +197,7 @@ namespace askap {
         casacore::Double channelFrequency = NEUtils::getFrequency(itsParset,itsChan);
 
         casacore::Quantity f0(baseFrequency,"Hz");
-      /// The width of a channel. THis does <NOT> take account of the variable width
+      /// The width of a channel. THis does NOT take account of the variable width
       /// of Barycentric channels
         casacore::Quantity freqinc(chanWidth,"Hz");
 

--- a/apps/askap/factory/NESpectralCube.h
+++ b/apps/askap/factory/NESpectralCube.h
@@ -41,8 +41,12 @@ namespace askap {
     * \param gitrepo $(GIT_REPO)
     * \param version $(PROJECT_VERSION)
     * \param category DynlibApp
-    * \param[in] param/Config
-    * \param[in] param/Normal
+    * \param[in] port/Config/LOFAR::ParameterSet
+    *     /~English ParameterSet descriptor for the image solver
+    *     /~Chinese
+    * \param[in] port/Normal/scimath::imagingNormalEquations
+    *     /~English ImagingNormalEquations to solve
+    *     /~Chinese
     * \par EAGLE_END
     */
     class NESpectralCube : public DaliugeApplication

--- a/apps/askap/factory/NESpectralCube.h
+++ b/apps/askap/factory/NESpectralCube.h
@@ -33,16 +33,20 @@
 
 
 namespace askap {
-
-    /// @brief Build an output image cube from input NormalEquations
-    /// @details This class builds the output cube is whatever format specified
-    /// by the parset.
-    ///
-
+    /*!
+    * \brief Build an output image cube from input NormalEquations
+    * \details This class builds the output cube is whatever format specified
+    * by the parset.
+    * \par EAGLE_START
+    * \param gitrepo $(GIT_REPO)
+    * \param version $(PROJECT_VERSION)
+    * \param category DynlibApp
+    * \param[in] param/Config
+    * \param[in] param/Normal
+    * \par EAGLE_END
+    */
     class NESpectralCube : public DaliugeApplication
-
     {
-
     public:
 
         typedef boost::shared_ptr<NESpectralCube> ShPtr;

--- a/apps/askap/factory/OutputParams.h
+++ b/apps/askap/factory/OutputParams.h
@@ -33,8 +33,12 @@ namespace askap {
     * \param gitrepo $(GIT_REPO)
     * \param version $(PROJECT_VERSION)
     * \param category DynlibApp
-    * \param[in] param/Config
-    * \param[out] param/Model
+    * \param[in] port/Config/LOFAR::ParameterSet
+    *     /~English ParameterSet descriptor for the image solver
+    *     /~Chinese
+    * \param[out] port/Model/scimath::Params
+    *     /~English
+    *     /~Chinese
     * \par EAGLE_END
     */
     class OutputParams : public DaliugeApplication

--- a/apps/askap/factory/OutputParams.h
+++ b/apps/askap/factory/OutputParams.h
@@ -26,13 +26,19 @@
 #include <measurementequation/ImageParamsHelper.h>
 
 namespace askap {
-  /// @brief Outputs the Params class as images
-  /// @details This drop actually generates the output images based upon the contents of the Params object
-  
+    /*!
+    * @brief Outputs the Params class as images
+    * @details This drop actually generates the output images based upon the contents of the Params object
+    * \par EAGLE_START
+    * \param gitrepo $(GIT_REPO)
+    * \param version $(PROJECT_VERSION)
+    * \param category DynlibApp
+    * \param[in] param/Config
+    * \param[out] param/Model
+    * \par EAGLE_END
+    */
     class OutputParams : public DaliugeApplication
-
     {
-
     public:
 
         typedef boost::shared_ptr<OutputParams> ShPtr;

--- a/apps/askap/factory/RestoreSolver.h
+++ b/apps/askap/factory/RestoreSolver.h
@@ -26,15 +26,22 @@
 #include <measurementequation/ImageParamsHelper.h>
 
 namespace askap {
-
-  /// @brief Implements an ASKAP Solver
-  /// @details This takes a configuration and a set of normal equations and uses the Solver requested in
-  /// in the ParameterSet to produce an ouput model.
-
+    /*!
+    * \brief Implements an ASKAP Solver
+    * \details This takes a configuration and a set of normal equations and uses the Solver requested in
+    * in the ParameterSet to produce an ouput model.
+    * \par EAGLE_START
+    * \param gitrepo $(GIT_REPO)
+    * \param version $(PROJECT_VERSION)
+    * \param category DynlibApp
+    * \param[in] param/Config
+    * \param[in] param/Model
+    * \param[in] param/Normal
+    * \param[out] param/Restored Model
+    * \par EAGLE_END
+    */
     class RestoreSolver : public DaliugeApplication
-
     {
-
     public:
 
         typedef boost::shared_ptr<RestoreSolver> ShPtr;

--- a/apps/askap/factory/RestoreSolver.h
+++ b/apps/askap/factory/RestoreSolver.h
@@ -34,10 +34,18 @@ namespace askap {
     * \param gitrepo $(GIT_REPO)
     * \param version $(PROJECT_VERSION)
     * \param category DynlibApp
-    * \param[in] param/Config
-    * \param[in] param/Model
-    * \param[in] param/Normal
-    * \param[out] param/Restored Model
+    * \param[in] port/Config/LOFAR::ParameterSet
+    *     /~English ParameterSet descriptor for the image solver
+    *     /~Chinese
+    * \param[in] port/Model/scimath::Params
+    *     /~English Params of solved normal equations
+    *     /~Chinese
+    * \param[in] port/Normal/scimath::ImagingNormalEquations
+    *     /~English ImagingNormalEquations to solve
+    *     /~Chinese
+    * \param[out] port/Restored Model/scimath::Params
+    *     /~English
+    *     /~Chinese
     * \par EAGLE_END
     */
     class RestoreSolver : public DaliugeApplication

--- a/apps/askap/factory/SolveNE.h
+++ b/apps/askap/factory/SolveNE.h
@@ -26,17 +26,22 @@
 #include <measurementequation/ImageParamsHelper.h>
 
 namespace askap {
-
-  /// @brief Implements an ASKAP Solver
-  /// @details This takes a configuration and a set of normal equations and uses the Solver requested in
-  /// in the ParameterSet to produce an ouput model.
-
+    /*!
+    * \brief Implements an ASKAP Solver
+    * \details This takes a configuration and a set of normal equations and uses the Solver requested in
+    * in the ParameterSet to produce an ouput model.
+    * \par EAGLE_START
+    * \param gitrepo $(GIT_REPO)
+    * \param version $(PROJECT_VERSION)
+    * \param category DynlibApp
+    * \param[in] param/Config
+    * \param[in] param/Normal
+    * \param[out] param/Model
+    * \par EAGLE_END
+    */
     class SolveNE : public DaliugeApplication
-
     {
-
     public:
-
         typedef boost::shared_ptr<SolveNE> ShPtr;
 
         SolveNE(dlg_app_info *raw_app);

--- a/apps/askap/factory/SolveNE.h
+++ b/apps/askap/factory/SolveNE.h
@@ -34,9 +34,15 @@ namespace askap {
     * \param gitrepo $(GIT_REPO)
     * \param version $(PROJECT_VERSION)
     * \param category DynlibApp
-    * \param[in] param/Config
-    * \param[in] param/Normal
-    * \param[out] param/Model
+    * \param[in] port/Config/LOFAR::ParameterSet
+    *     /~English ParameterSet descriptor for the image solver
+    *     /~Chinese
+    * \param[in] port/Normal/scimath::ImagingNormalEquations
+    *     /~English ImagingNormalEquations to solve
+    *     /~Chinese
+    * \param[out] port/Model/scimath::Params
+    *     /~English Params of solved normal equations
+    *     /~Chinese
     * \par EAGLE_END
     */
     class SolveNE : public DaliugeApplication

--- a/apps/askap/factory/SpectralCube.cc
+++ b/apps/askap/factory/SpectralCube.cc
@@ -219,7 +219,7 @@ namespace askap {
 
 
         casacore::Quantity f0(baseFrequency,"Hz");
-    /// The width of a channel. THis does <NOT> take account of the variable width
+    /// The width of a channel. THis does NOT take account of the variable width
     /// of Barycentric channels
         casacore::Quantity freqinc(chanWidth,"Hz");
 

--- a/apps/askap/factory/SpectralCube.h
+++ b/apps/askap/factory/SpectralCube.h
@@ -41,8 +41,15 @@ namespace askap {
     * \param gitrepo $(GIT_REPO)
     * \param version $(PROJECT_VERSION)
     * \param category DynlibApp
-    * \param[in] param/Config
-    * \param[in] param/Model
+    * \param[in] port/Config/LOFAR::ParameterSet
+    *     /~English ParameterSet descriptor for the image solver
+    *     /~Chinese
+    * \param[in] port/Model/scimath::Params
+    *     /~English Params of solved normal equations
+    *     /~Chinese
+    * \param[out] port/Cube/undefined
+    *     /~English
+    *     /~Chinese
     * \par EAGLE_END
     */
     class SpectralCube : public DaliugeApplication

--- a/apps/askap/factory/SpectralCube.h
+++ b/apps/askap/factory/SpectralCube.h
@@ -32,15 +32,21 @@
 
 namespace askap {
 
-    /// @brief Build the output image cube
-    /// @details This class builds the output cube is whatever format specified
-    /// by the parset.
-    ///
 
+    /*!
+    * \brief Build the output image cube
+    * \details This class builds the output cube is whatever format specified
+    * by the parset.
+    * \par EAGLE_START
+    * \param gitrepo $(GIT_REPO)
+    * \param version $(PROJECT_VERSION)
+    * \param category DynlibApp
+    * \param[in] param/Config
+    * \param[in] param/Model
+    * \par EAGLE_END
+    */
     class SpectralCube : public DaliugeApplication
-
     {
-
     public:
 
         typedef boost::shared_ptr<SpectralCube> ShPtr;


### PR DESCRIPTION
This change adds EAGLE descriptions inline with jacal component source files that were previously located here: https://github.com/ICRAR/EAGLE_test_repo/blob/master/JACAL/jacal.palette

Port names have been updated here to match the strings used in the c++ implementation.